### PR TITLE
Update AdGuard Home to v0.106.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
     # https://hub.docker.com/r/adguard/adguardhome
     adguard:
-        image: adguard/adguardhome:v0.106.0
+        image: adguard/adguardhome:v0.106.2
         network_mode: host
         privileged: true
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
     # https://hub.docker.com/r/adguard/adguardhome
     adguard:
-        image: adguard/adguardhome:v0.105.2
+        image: adguard/adguardhome:v0.106.0
         network_mode: host
         privileged: true
         volumes:


### PR DESCRIPTION
Alternatively, we can change it to image: adguard/adguardhome:latest to always pull the latest: https://hub.docker.com/r/adguard/adguardhome/tags?page=1&ordering=last_updated