### PR TITLE
Upgrade to AdGuard v0.106.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
     # https://hub.docker.com/r/adguard/adguardhome
     adguard:
-        image: adguard/adguardhome:v0.105.2
+        image: adguard/adguardhome:v0.106.3
         network_mode: host
         privileged: true
         volumes:


### PR DESCRIPTION
Upgrade to AdGuard v0.106.3
https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.106.3

To be held until May 26, 2021.