### PR TITLE
Optionally run external PRs with elevated permissions 

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -1,18 +1,21 @@
 name: balena
 
 on:
-  pull_request:
-    types: [opened, synchronize, closed]
+  pull_request_target:
+    types: [opened, synchronize, closed, labeled]
     branches:
       - main
 
 jobs:
   build:
-    if: github.actor == github.repository_owner
+    if: github.actor == github.repository_owner || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: balena-io/balena-ci@v0.5.0
         with:

--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -24,4 +24,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           versionbot: false
           environment: balena-cloud.com
-          create_tag: true
+          create_tag: false


### PR DESCRIPTION
External PRs from forks or bots do not have access to GH secrets
and cannot deploy to balenaCloud.

However, if an admistrator adds the flag `ok-to-test` we should
allow the elevated `pull_request_target` to run.

See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Signed-off-by: Kyle Harding <kyle@balena.io>